### PR TITLE
Setting to disable thumbnail generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Ability to rename tickets. Contributed by @fiedl.
 - Canned replies. Contributed by @svoop.
 - Support for incoming mail from Mailgun. Contributed by @svoop.<br>:warning: If you are already using the `post-mail` script, you must update the `aliases` file of your MTA according to the example mentioned in the README!
+- Support for disabling thumbnail generation.
 
 ### Changed
 - Better error messages when an invalid input is given for non-signed in users. Contributed by @mickael-kerjean.

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -39,7 +39,7 @@ class Attachment < ApplicationRecord
 
   def thumbnail?
 
-    return false if disable_thumbnail_generation
+    return false if disable_thumbnail_generation || !AppSettings.enable_attachment_thumbnails
 
     unless file_content_type.nil?
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -6,6 +6,7 @@ default: &defaults
   custom_stylesheet_url:
   enable_custom_javascript: false
   custom_javascript_url:
+  enable_attachment_thumbnails: true
 
 development:
   <<: *defaults


### PR DESCRIPTION
Thumbnail generation seems to be a recurring issue when pushing mail into Brimir.

As we don't tend to use it ourselves, this setting allows you to explicitly disable all thumbnail generation for new emails in Brimir.